### PR TITLE
Feature 39183517 cuc pass parameters to cucumber

### DIFF
--- a/lib/geordi/cuc.rb
+++ b/lib/geordi/cuc.rb
@@ -53,7 +53,7 @@ module Geordi
       end
     end
 
-    #private
+    private
 
     attr_writer :argv
     def argv
@@ -61,30 +61,12 @@ module Geordi
     end
 
     def serial_execution_command
-      if argv.include?('--format' || '-f')
-        format_arg = argv.split(' ')[argv.split(' ').index('--format' || '-f') + 1]
-        format_args = ['--format', format_arg]
-      else
+      format_args = []
+      unless argv.include?('--format') || argv.include?('-f')
         format_args = spinner_available? ? ['--format', 'CucumberSpinner::CuriousProgressBarFormatter'] : ['--format', 'progress']
       end
-      [use_firefox_for_selenium, "b", "cucumber", format_args, escape_shell_args(argv.split(' ').last)].flatten.compact.join(" ")
+      [use_firefox_for_selenium, "b", "cucumber", format_args, escape_shell_args(argv)].flatten.compact.join(" ")
     end
-
-
-    def get_execution_options
-      format_args = []
-      unless argv.empty?
-        options = argv.split(' ')
-        options.each do |option|
-          if option.start_with?('--' || '-')
-            format_args << option
-            format_args << value
-          end
-        end
-      end
-      format_args
-    end
-
 
     def parallel_execution_command
       puts "Using parallel_tests ...\n\n"


### PR DESCRIPTION
Parameters will be already passed to cucumber. Just made it possible to overwrite the --format/-f parameter.
Additionally fixed the double message about the firefox version.
