### PR TITLE
Remove db name prefix when reading whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Fixes [#3]: Add spring support for RSpec
 - Fixes [#53]: Integrate yarn integrity
 - Fixes [#52]: Remote dumps are transmitted compressed
+- Fixes [#59]: Removedb name prefix when reading whitelist
 
 ## 1.11.0 2018-11-07
 


### PR DESCRIPTION
If users manually added the `keep` prefix to the whitelist file on disk,
remove this prefix when reading the file to avoid syntax errors.

Fixes #59