### PR TITLE
Add details to error msgs when whitelist editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 - Fixes [#54]: @solo features run first and are not skipped by accident on failures before
-- Fixes [#3]: Add spring support for RSpec
+- Fixes [#03]: Add spring support for RSpec
 - Fixes [#53]: Integrate yarn integrity
 - Fixes [#52]: Remote dumps are transmitted compressed
+- Fixes [#62]: Provide better error messages on whitelist editing errors.
 
 ## 1.11.0 2018-11-07
 

--- a/lib/geordi/db_cleaner.rb
+++ b/lib/geordi/db_cleaner.rb
@@ -64,8 +64,12 @@ HEREDOC
         lines = Geordi::Util.stripped_lines(wl_edited.read)
         lines.each do |line|
           next if line.start_with?('#')
-          fail 'Invalid edit to whitelist file' unless line.split.length == 2
-          fail 'Invalid edit to whitelist file' unless %w[keep drop k d].include? line.split[0]
+          unless line.split.length == 2
+            fail "Invalid edit to whitelist file: \`#{line}\` - Syntax is: ^[keep|drop] dbname$"
+          end
+          unless %w[keep drop k d].include? line.split.first
+            fail "Invalid edit to whitelist file: \`#{line}\` - must start with either drop or keep."
+          end
           db_status, db_name = line.split
           if db_status == 'keep'
             whitelisted_dbs.push db_name


### PR DESCRIPTION
Output line that caused whitelist validation to fail and specify how the
correct syntax should look.

Fixes #61 