### PR TITLE
Allow explicit whitelisting of derivative dbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 - Fixes [#54]: @solo features run first and are not skipped by accident on failures before
-- Fixes [#3]: Add spring support for RSpec
+- Fixes [#03]: Add spring support for RSpec
 - Fixes [#53]: Integrate yarn integrity
 - Fixes [#52]: Remote dumps are transmitted compressed
+- Fixes [#63]: Allow explicit whitelisting of database names that would be considered derivative during db cleanup
 
 ## 1.11.0 2018-11-07
 

--- a/lib/geordi/db_cleaner.rb
+++ b/lib/geordi/db_cleaner.rb
@@ -223,7 +223,15 @@ HEREDOC
       else
         whitelist_content = Array.new
       end
-      whitelist_content.include? database_name.sub(@derivative_dbname, '')
+      # Allow explicit whitelisting of derivative databases like projectname_test2
+      if whitelist_content.include? database_name
+        true
+      # whitelisting `projectname` also whitelists `projectname_test\d+`, `projectname_development`
+      elsif whitelist_content.include? database_name.sub(@derivative_dbname, '')
+        true
+      else
+        false
+      end
     end
 
     def filter_whitelisted(dbtype, database_list)


### PR DESCRIPTION
Databases with derivative names that have been whitelisted explicitly even though the apex database name has not should always be kept.