### PR TITLE
Remove VISUAL and EDITOR from editor choices for DB whitelist editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 - Fixes [#54]: @solo features run first and are not skipped by accident on failures before
-- Fixes [#3]: Add spring support for RSpec
+- Fixes [#03]: Add spring support for RSpec
 - Fixes [#53]: Integrate yarn integrity
 - Fixes [#52]: Remote dumps are transmitted compressed
+- Fixes [#64]: Remove VISUAL and EDITOR from editor choices for DB whitelist editing
 
 ## 1.11.0 2018-11-07
 

--- a/lib/geordi/util.rb
+++ b/lib/geordi/util.rb
@@ -82,7 +82,7 @@ module Geordi
 
       # try to guess user's favorite cli text editor
       def decide_texteditor
-        %w[$VISUAL $EDITOR /usr/bin/editor vi].each do |texteditor|
+        %w[/usr/bin/editor vi].each do |texteditor|
           if cmd_exists? texteditor and texteditor.start_with? '$'
             return ENV[texteditor[1..-1]]
           elsif cmd_exists? texteditor


### PR DESCRIPTION
# Problem

Currently `geordi drop-databases` will check `%w[$VISUAL $EDITOR /usr/bin/editor vim]`. If users have `$VISUAL` or `$EDITOR` set to an editor that does not follow the expected behavior of opening the database whitelist file, saving changes and returning, whitelist editing will not work. It will work fine for `nano`, `vim`, etc.

Either a) geordi won't continue until the process it called has exited, which might not happen for a long time if the editor is a long-running instance of a GUI editor or b) the editor will return immediately after opening the file, before any changes have been made and saved to the whitelist, resulting in geordi reading an unchanged file and continuing.

# Proposed solution

Eliminating those variables from consideration as the text editor for editing whitelists seems to be the most straightforward solution for now. Adding a configuration option for all of geordi that lets users chose their own editor seems out of scope for this issue. Choice remains with the user insofar as the next editor in line for consideration would be `/usr/bin/editor` which on Debian and Ubuntu is symlinked to what the user specifies by running `sudo update-alterantives --config editor`, defaulting to `nano` and limited to CLI editors. Last in line would be plain `vi` since it's part of POSIX.