### PR TITLE
Show adapter type before asking for the DB password

### DIFF
--- a/lib/geordi/commands/create_database_yml.rb
+++ b/lib/geordi/commands/create_database_yml.rb
@@ -6,10 +6,12 @@ def create_database_yml
   if File.exists?(sample_yml) and not File.exists?(real_yml)
     announce 'Creating ' + real_yml
 
-    print 'Please enter your DB password: '
+    sample = File.read(sample_yml)
+    adapter = sample.match(/adapter: (\w+)\n/).captures.first
+
+    print "Please enter your #{adapter} password: "
     db_password = STDIN.gets.strip
 
-    sample = File.read(sample_yml)
     real = sample.gsub(/password:.*$/, "password: #{db_password}")
     File.open(real_yml, 'w') { |f| f.write(real) }
 


### PR DESCRIPTION
When you are working on different projects that are using different kinds of databases, I think it would be helpful for the developer to be presented the kind of database he is asked to provide the password for.