### PR TITLE
Add host parameter to mysql dump loader

### DIFF
--- a/lib/geordi/dump_loader.rb
+++ b/lib/geordi/dump_loader.rb
@@ -18,12 +18,13 @@ module Geordi
       @config['development']
     end
     alias_method :config, :development_database_config
-  
+
     def mysql_command
       command = 'mysql --silent'
       command << ' -p' << config['password'].to_s if config['password']
       command << ' -u' << config['username'].to_s if config['username']
       command << ' --port=' << config['port'].to_s if config['port']
+      command << ' --host=' << config['host'].to_s if config['host']
       command << ' --default-character-set=utf8'
       command << ' ' << config['database'].to_s
       command << ' < ' << dump_file


### PR DESCRIPTION
I tried to load a dump in a project using mysql-sandbox and noticed, that it wouldn't accept the host parameter.