### PR TITLE
Fix false "geordi commit" message (closes #83)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/*
 .DS_Store
 .pt_project_id
 tmp
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -385,6 +385,9 @@ calling your local geordi like so (adjust paths to your needs):
 
     # @option -I: add directory to load path
     ruby -I ../geordi/lib ../geordi/bin/geordi <command>
+    
+    # with debugger
+    ruby -r byebug -I ../geordi/lib ../geordi/bin/geordi <command>
 
 Don't forget to update this README. The whole `geordi` section is auto-generated
 by `rake readme`. Also remember to add your changes to the CHANGELOG.

--- a/lib/geordi/util.rb
+++ b/lib/geordi/util.rb
@@ -94,7 +94,7 @@ module Geordi
           ENV['GEORDI_TESTING_STAGED_CHANGES'] == 'true'
         else
           statuses = `git status --porcelain`.split("\n")
-          statuses.any? { |l| l.start_with? 'A' }
+          statuses.any? { |l| l.start_with? /[A-Z]/i }
         end
       end
 


### PR DESCRIPTION
"geordi commit" would print a warning "no staged changes" unless new files were staged.
Now it respects **any** staged changes.

