### PR TITLE
Fix deprecation warning: exit 0 on error (closes #84)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/*
 .DS_Store
 .pt_project_id
 tmp
+.byebug_history

--- a/lib/geordi/cli.rb
+++ b/lib/geordi/cli.rb
@@ -7,6 +7,10 @@ module Geordi
   class CLI < Thor
     include Geordi::Interaction
 
+    def self.exit_on_failure?
+      true
+    end
+
     # load all tasks defined in lib/geordi/commands
     Dir[File.expand_path '../commands/*.rb', __FILE__].each do |file|
       class_eval File.read(file), file


### PR DESCRIPTION
When typing in an unknown geordi command, you got the following deprecation warning with status code 0:

> Deprecation warning: Thor exit with status 0 on errors.

This was fixed by overwriting the `exit_on_failure` method. Now it returns the status code 1.