### PR TITLE
Update security-update for improved workflow (closes #89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+- Update security-update for improved workflow (#89): Deploy staging first and ask user, if application is still running. Then deploy other stages.
+
 ### Breaking changes
 
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Commit using a story title from Pivotal Tracker.
 
 Example: `geordi commit`
 
+Any extra arguments are forwarded to `git commit -m <message>`.
+
+If there are no staged changes, prints a warning but will continue to create
+an empty commit.
+
 On the first execution we ask for your Pivotal Tracker API token. It will be
 stored in `~/.gitpt`.
 
@@ -255,10 +260,30 @@ Support for performing security updates.
 
 Preparation for security update: `geordi security-update`
 
+Checks out production and pulls.
+
 After performing the update: `geordi security-update finish`
 
 Switches branches, pulls, pushes and deploys as required by our workflow. Tells
-what it will do before it does it.
+what it will do before it does it. In detail:
+
+1. Asks user, if tests are green
+
+2. Pushes production
+
+3. Checks out master and pulls
+
+4. Merges production and pushes in master
+
+5. Deploys staging first, if there is a staging environment
+
+6. Asks user, if deployment log is okay and application is still running on staging
+
+7. Deploys other stages
+
+8. Asks user, if deployment log is okay and application is still running on all other stages
+
+9. Informs user about the next steps
 
 
 ### `geordi server [PORT]`

--- a/features/security_update.feature
+++ b/features/security_update.feature
@@ -1,0 +1,205 @@
+Feature: The security-update command
+
+  Scenario: Preparing the security-update
+    Unfortunately, Aruba cannot run commands truly interactively. We need to
+    answer prompts blindly, and check the output afterwards.
+
+    When I run `geordi security-update` interactively
+      # Answer prompt "Continue?"
+      And I type "yes"
+
+    Then the output should contain:
+      """
+      # Preparing for security update
+      > Please read https://makandracards.com/makandra/1587 before applying security updates!
+      > About to checkout production and pull.
+      Continue? [y]
+      """
+      And the output should contain:
+      """
+      Util.system! git checkout production
+      """
+      And the output should contain:
+      """
+      > git pull
+      Util.system! git pull
+
+      > Successfully prepared for security update
+
+      > Please apply the security update now and commit your changes.
+      > When you are done, run `geordi security-update finish`.
+      """
+
+
+  Scenario: Finishing the security-update with staging and production deploy targets
+    Given a file named "config/deploy/staging.rb" with "staging.rb exists"
+      And a file named "config/deploy/production.rb" with "production.rb exists"
+
+    When I run `geordi security-update finish` interactively
+      # Answer prompt "Have you successfully run all tests?"
+      And I type "yes"
+      # Answer prompt "Continue?"
+      And I type "yes"
+      # Answer prompt "Deploy staging now?"
+      And I type "yes"
+      # Answer prompt "Is the deployment log okay and the application is still running on staging?"
+      And I type "yes"
+      # Answer prompt "Deploy other stages now?"
+      And I type "yes"
+      # Answer prompt "Is the application still running on all other stages and the logs are okay?"
+      And I type "yes"
+    Then the output should contain:
+      """
+      Util.system! git status --porcelain
+
+      # Finishing security update
+      > Working directory clean.
+      Have you successfully run all tests? [n]
+      """
+      And the output should contain:
+      """
+      > About to: push production, checkout & pull master, merge production, push master.
+      Continue? [n]
+      """
+      And the output should contain:
+      """
+      > git push
+      Util.system! git push
+      > git checkout master
+      Util.system! git checkout master
+      > git pull
+      Util.system! git pull
+      > git merge production
+      Util.system! git merge production
+      > git push
+      Util.system! git push
+
+      # Deployment
+      > There is a staging environment.
+      Deploy staging now? [y]
+      """
+      And the output should contain:
+      """
+      # Deploy staging
+      > bundle exec cap staging deploy:migrations
+      Util.system! bundle exec cap staging deploy:migrations
+      Is the deployment log okay and the application is still running on staging? [y]
+      """
+      And the output should contain:
+      """
+      > Found the following other stages:
+      production
+
+      Deploy other stages now? [y]
+      """
+      And the output should contain:
+      """
+      # Deploy production
+      > bundle exec cap production deploy:migrations
+      Util.system! bundle exec cap production deploy:migrations
+      Is the application still running on all other stages and the logs are okay? [y]
+      """
+      And the output should contain:
+      """
+      > Successfully pushed and deployed security update
+
+      > Now send an email to customer and project lead, informing them about the update.
+      > Do not forget to make a joblog on a security budget, if available.
+      """
+
+  Scenario: Finishing the security-update without deploy targets
+    When I run `geordi security-update finish` interactively
+      # Answer prompt "Have you successfully run all tests?"
+      And I type "yes"
+      # Answer prompt "Continue?"
+      And I type "yes"
+    Then the output should contain:
+      """
+      Util.system! git status --porcelain
+
+      # Finishing security update
+      > Working directory clean.
+      Have you successfully run all tests? [n]
+      """
+    And the output should contain:
+      """
+      > About to: push production, checkout & pull master, merge production, push master.
+      Continue? [n]
+      """
+    And the output should contain:
+      """
+      > git push
+      Util.system! git push
+      > git checkout master
+      Util.system! git checkout master
+      > git pull
+      Util.system! git pull
+      > git merge production
+      Util.system! git merge production
+      > git push
+      Util.system! git push
+
+      # Deployment
+
+      x There are no deploy targets!
+      """
+
+  Scenario: Finishing the security-update without staging target
+    Given a file named "config/deploy/production.rb" with "production.rb exists"
+    When I run `geordi security-update finish` interactively
+      # Answer prompt "Have you successfully run all tests?"
+      And I type "yes"
+      # Answer prompt "Continue?"
+      And I type "yes"
+      # Answer prompt "Deploy other stages now?"
+      And I type "yes"
+      # Answer prompt "Is the application still running on all other stages and the logs are okay?"
+      And I type "yes"
+
+     # Only relevant output excerpt
+    Then the output should contain:
+      """
+      # Deployment
+      > There is no staging environment.
+
+      > Found the following other stages:
+      production
+
+      Deploy other stages now? [y]
+      """
+
+  Scenario: Finishing the security-update with only staging target
+    Given a file named "config/deploy/staging.rb" with "staging.rb exists"
+    When I run `geordi security-update finish` interactively
+      # Answer prompt "Have you successfully run all tests?"
+      And I type "yes"
+      # Answer prompt "Continue?"
+      And I type "yes"
+      # Answer prompt "Deploy staging now?"
+      And I type "yes"
+      # Answer prompt "Is the deployment log okay and the application is still running on staging?"
+      And I type "yes"
+
+     # Only relevant output excerpt
+    Then the output should contain:
+      """
+      # Deployment
+      > There is a staging environment.
+      Deploy staging now? [y]
+      """
+      And the output should contain:
+      """
+      # Deploy staging
+      > bundle exec cap staging deploy:migrations
+      Util.system! bundle exec cap staging deploy:migrations
+      Is the deployment log okay and the application is still running on staging? [y]
+      """
+      And the output should contain:
+      """
+      > There are no other stages.
+
+      > Successfully pushed and deployed security update
+
+      > Now send an email to customer and project lead, informing them about the update.
+      > Do not forget to make a joblog on a security budget, if available.
+      """

--- a/features/support/aruba_config.rb
+++ b/features/support/aruba_config.rb
@@ -1,0 +1,3 @@
+Before do
+  @aruba_timeout_seconds = 5
+end


### PR DESCRIPTION
Improved the workflow for security-update finish.
Now staging is deployed first, if there is a staging environment.
After that, the user is prompted to check the log and if the application is still running.
If everything is fine, all other stages will be deployed and the user will be prompted again to check the application.
Also added cucumber tests for that and updated the README.