### PR TITLE
Add helper class for settings and allow disabling vnc (closes #91)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 .idea
 pkg/*
 .DS_Store
-.pt_project_id
 tmp
 .byebug_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Add #91: Now there is an option to start cucumber without a VNC session. This is configured by the .geordi.yml file.
 - Deprecated the `.pt_project_id` file in favor of `.geordi.yml`.
 - Deprecated the `~/.gitpt` file in favor of `~/.config/geordi/global.yml`.
+- Fixed `git#staged_changes?` detection on Ruby < 2.5.
+
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+### Breaking changes
+
+## 3.2.0 2020-06-24
+
+### Compatible changes
+
 - Add a `.geordi.yml` file to change multiple settings in the project and  `~/.config/geordi/global.yml` for global settings.
 - Add #91: Now there is an option to start cucumber without a VNC session. This is configured by the .geordi.yml file.
 - Deprecated the `.pt_project_id` file in favor of `.geordi.yml`.
 - Deprecated the `~/.gitpt` file in favor of `~/.config/geordi/global.yml`.
 - Fixed `git#staged_changes?` detection on Ruby < 2.5.
-
-
-### Breaking changes
 
 
 ## 3.1.0 2020-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+- Add a `.geordi.yml` file to change multiple settings in the project and  `~/.config/geordi/global.yml` for global settings.
+- Add #91: Now there is an option to start cucumber without a VNC session. This is configured by the .geordi.yml file.
+- Deprecated the `.pt_project_id` file in favor of `.geordi.yml`.
+- Deprecated the `~/.gitpt` file in favor of `~/.config/geordi/global.yml`.
+
 ### Breaking changes
 
 
@@ -16,8 +21,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Compatible changes
 
 - Update security-update for improved workflow (#89): Deploy staging first and ask user, if application is still running. Then deploy other stages.
-
-### Breaking changes
 
 
 ## 3.0.3 2020-05-27
@@ -31,7 +34,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
-- Fix #95: Method change from `! *.include?` to `*.exclude?` was not valid as we do not have active support in Geordi. Affected commands where `geordi cucumber` and `geordi deploy`.
+- Fix #95: Method change from `! *.include?` to `*.exclude?` was not valid as we do not have active support in Geordi. Affected commands were `geordi cucumber` and `geordi deploy`.
 
 ### Breaking changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    geordi (3.1.0)
+    geordi (3.2.0)
       thor (~> 1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If there are no staged changes, prints a warning but will continue to create
 an empty commit.
 
 On the first execution we ask for your Pivotal Tracker API token. It will be
-stored in `~/.gitpt`.
+stored in `~/.config/geordi/global.yml`.
 
 
 ### `geordi console [TARGET]`
@@ -91,6 +91,12 @@ or `-d`.
 
 - *Options:* Any unknown option will be passed through to Cucumber,
 e.g. `--format pretty`.
+
+- *VNC:* By default, test browsers will run in a VNC session. When using a
+headless test browser anyway, you can disable VNC by putting the following
+config into `.geordi.yml` in the project root:
+
+    use_vnc: false
 
 
 ### `geordi delete-dumps [DIRECTORY]`

--- a/lib/geordi/commands/commit.rb
+++ b/lib/geordi/commands/commit.rb
@@ -9,7 +9,7 @@ If there are no staged changes, prints a warning but will continue to create
 an empty commit.
 
 On the first execution we ask for your Pivotal Tracker API token. It will be
-stored in `~/.gitpt`.
+stored in `~/.config/geordi/global.yml`.
 LONGDESC
 
 def commit(*git_args)

--- a/lib/geordi/commands/cucumber.rb
+++ b/lib/geordi/commands/cucumber.rb
@@ -15,6 +15,13 @@ or `-d`.
 
 - *Options:* Any unknown option will be passed through to Cucumber,
 e.g. `--format pretty`.
+
+- *VNC:* By default, test browsers will run in a VNC session. When using a
+headless test browser anyway, you can disable VNC by putting the following
+config into `.geordi.yml` in the project root:
+
+    use_vnc: false
+
 LONGDESC
 
 option :modified, aliases: '-m', type: :boolean,

--- a/lib/geordi/cucumber.rb
+++ b/lib/geordi/cucumber.rb
@@ -5,6 +5,7 @@ require 'tempfile'
 # version of Geordi.
 require File.expand_path('interaction', __dir__)
 require File.expand_path('firefox_for_selenium', __dir__)
+require File.expand_path('settings', __dir__)
 
 module Geordi
   class Cucumber
@@ -16,10 +17,11 @@ module Geordi
 
     def run(files, cucumber_options, options = {})
       self.argv = files + cucumber_options.map { |option| option.split('=') }.flatten
+      self.settings = Geordi::Settings.new
 
       consolidate_rerun_txt_files
       show_features_to_run
-      setup_vnc
+      setup_vnc if settings.use_vnc?
 
       command = use_parallel_tests?(options) ? parallel_execution_command : serial_execution_command
       Interaction.note_cmd(command) if options[:verbose]
@@ -65,7 +67,7 @@ module Geordi
 
     private
 
-    attr_accessor :argv
+    attr_accessor :argv, :settings
 
     def serial_execution_command
       format_args = []

--- a/lib/geordi/settings.rb
+++ b/lib/geordi/settings.rb
@@ -1,0 +1,155 @@
+require 'yaml'
+
+require File.expand_path('util', __dir__)
+require File.expand_path('interaction', __dir__)
+
+module Geordi
+  class Settings
+    GLOBAL_SETTINGS_FILE_NAME = Util.testing? ? './tmp/global_settings.yml'.freeze : File.join(ENV['HOME'], '.config/geordi/global.yml').freeze
+    LOCAL_SETTINGS_FILE_NAME = Util.testing? ? './tmp/local_settings.yml'.freeze : './.geordi.yml'.freeze
+
+    ALLOWED_GLOBAL_SETTINGS = %w[ pivotal_tracker_api_key ].freeze
+    ALLOWED_LOCAL_SETTINGS = %w[ use_vnc pivotal_tracker_project_ids ].freeze
+
+    def initialize
+      read_settings
+    end
+
+    # Global settings
+    def pivotal_tracker_api_key
+      @global_settings['pivotal_tracker_api_key'] || gitpt_api_key_old || inquire_pt_api_key
+    end
+
+    def pivotal_tracker_api_key=(value)
+      @global_settings['pivotal_tracker_api_key'] = value
+      save_global_settings
+    end
+
+    # Local settings
+    # They should not be changed by geordi to avoid unexpected diffs, therefore
+    # there are no setters for these settings
+    def use_vnc?
+      @local_settings.fetch('use_vnc', true)
+    end
+
+    def pivotal_tracker_project_ids
+      project_ids = @local_settings['pivotal_tracker_project_ids'] || pt_project_ids_old
+
+      case project_ids
+      when Array
+        # nothing to do
+      when String
+        project_ids = project_ids.split(/[\s]+/).map(&:to_i)
+      when Integer
+        project_ids = [project_ids]
+      else
+        project_ids = []
+      end
+
+      if project_ids.empty?
+        puts
+        Geordi::Interaction.warn "Sorry, I could not find a project ID in .geordi.yml :("
+        puts
+
+        puts "Please put at least one Pivotal Tracker project id into the .geordi.yml file in this directory, e.g."
+        puts
+        puts "pivotal_tracker_project_ids:"
+        puts "- 123456"
+        puts
+        puts 'You may add multiple IDs.'
+        exit 1
+      end
+
+      project_ids
+    end
+
+    private
+
+    def read_settings
+      global_path = GLOBAL_SETTINGS_FILE_NAME
+      local_path = LOCAL_SETTINGS_FILE_NAME
+
+      if File.exists?(global_path)
+        global_settings = YAML.safe_load(File.read(global_path))
+        check_for_invalid_keys(global_settings, ALLOWED_GLOBAL_SETTINGS, global_path)
+      end
+
+      if File.exists?(local_path)
+        local_settings = YAML.safe_load(File.read(local_path))
+        check_for_invalid_keys(local_settings, ALLOWED_LOCAL_SETTINGS, local_path)
+      end
+
+      @global_settings = global_settings || {}
+      @local_settings = local_settings || {}
+    end
+
+    def check_for_invalid_keys(settings, allowed_keys, file)
+      invalid_keys = settings.keys - allowed_keys
+      unless invalid_keys.empty?
+        Geordi::Interaction.warn "Geordi detected unknown keys in #{file}.\n"
+
+        invalid_keys.sort.each do |key|
+          puts "* #{key}"
+        end
+
+        puts "\nAllowed keys are:"
+        allowed_keys.sort.each do |key|
+          puts "* #{key}"
+        end
+        puts
+
+        exit 1
+      end
+    end
+
+    def save_global_settings
+      global_path = GLOBAL_SETTINGS_FILE_NAME
+      global_directory = File.dirname(global_path)
+      FileUtils.mkdir_p(global_directory) unless File.directory? global_directory
+      File.open(global_path, 'w') do |file|
+        file.write @global_settings.to_yaml
+      end
+    end
+
+    # deprecated
+    def gitpt_api_key_old
+      file_path = File.join(ENV['HOME'], '.gitpt')
+      if File.exist?(file_path)
+        token = YAML.load_file(file_path).fetch :token
+        self.pivotal_tracker_api_key = token
+
+        Geordi::Interaction.warn "The ~/.gitpt file is deprecated."
+        Geordi::Interaction.note "The contained setting has been moved to ~/.config/geordi/global.yml."
+        Geordi::Interaction.note "If you don't need to work with an older version of geordi you can delete ~/.gitpt now."
+
+        token
+      end
+    end
+
+    def inquire_pt_api_key
+      Geordi::Interaction.warn 'Your settings are missing or invalid.'
+      Geordi::Interaction.warn "Please configure your Pivotal Tracker access."
+      token = Geordi::Interaction.prompt 'Your API key:'
+      self.pivotal_tracker_api_key = token
+      puts
+
+      token
+    end
+
+    # deprecated
+    def pt_project_ids_old
+      if File.exist?('.pt_project_id')
+        project_ids = File.read('.pt_project_id')
+        puts # Make sure to start on a new line (e.g. when invoked after a #print)
+        Geordi::Interaction.warn "The usage of the .pt_project_id file is deprecated."
+        Geordi::Interaction.note Util.strip_heredoc(<<-INSTRUCTIONS)
+          Please remove this file from your project and add or extend the .geordi.yml file with the following content:
+            pivotal_tracker_project_ids: #{project_ids}
+        INSTRUCTIONS
+
+        project_ids
+      end
+    end
+
+  end
+end

--- a/lib/geordi/util.rb
+++ b/lib/geordi/util.rb
@@ -93,7 +93,7 @@ module Geordi
           ENV['GEORDI_TESTING_STAGED_CHANGES'] == 'true'
         else
           statuses = `git status --porcelain`.split("\n")
-          statuses.any? { |l| l.start_with? /[A-Z]/i }
+          statuses.any? { |l| /^[A-Z]/i =~ l }
         end
       end
 

--- a/lib/geordi/version.rb
+++ b/lib/geordi/version.rb
@@ -1,3 +1,3 @@
 module Geordi
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.2.0'.freeze
 end


### PR DESCRIPTION
Wrote a settings class which reads from `.geordi.yml` and `~/.config/geordi/global.yml`.  
Updated `geordi commit` to use the new settings, deprecated the old `.pt_project_id` and `~/.gitpt` files.
Added an option to `geordi cucumber` to skip the vnc session via an option in `.geordi.yml`