### PR TITLE
Let --select-server option take the number of the server to skip the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- Improvement #43: `--select-server` option on `geordi shell` and `geordi console` can take the number of the server to connect to it directly and to skip the menu.
+
 ### Compatible changes
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Open a local Rails console: `geordi console`
 
 Open a Rails console on `staging`: `geordi console staging`
 
+Lets you select the server to connect to from a menu when called with `--select-server` or the alias `-s`:
+
+    geordi console staging -s
+
+If you already know the number of the server you want to connect to, just pass it along:
+
+    geordi console staging -s2
+
 
 ### `geordi cucumber [FILES and OPTIONS]`
 
@@ -320,9 +328,13 @@ Open a shell on a Capistrano deploy target.
 
 Example: `geordi shell production`
 
-Lets you select the server to connect to when called with `--select-server`:
+Lets you select the server to connect to from a menu when called with `--select-server` or the alias `-s`:
 
     geordi shell production -s
+
+If you already know the number of the server you want to connect to, just pass it along:
+
+    geordi shell production -s2
 
 
 ### `geordi tests`

--- a/features/shell.feature
+++ b/features/shell.feature
@@ -4,7 +4,7 @@ Feature: The shell command
     Given a file named "Capfile" with "Capfile exists"
 
 
-  Scenario: It opens a remote shell on the primary server
+  Scenario: It opens a remote shell on the primary server when no option is given
     Given a file named "config/deploy.rb" with "deploy.rb exists"
     And a file named "config/deploy/geordi.rb" with:
     """
@@ -15,6 +15,62 @@ Feature: The shell command
     """
 
     When I run `geordi shell geordi`
+    Then the output should contain "Util.system! ssh, deploy@first.example.com, -t, cd /var/www/example.com/current && bash --login"
+
+  Scenario: It opens a menu to select the server to connect to when the select server option is given
+    Given a file named "config/deploy.rb" with "deploy.rb exists"
+    And a file named "config/deploy/geordi.rb" with:
+    """
+    set :user, 'deploy'
+    set :deploy_to, '/var/www/example.com'
+    server 'first.example.com'
+    server 'second.example.com'
+    """
+
+    When I run `geordi shell geordi --select-server` interactively
+      # Answer prompt "Connect to? [1]"
+      And I type "2"
+    Then the output should contain "# Opening a shell on geordi"
+    Then the output should contain "Util.system! ssh, deploy@second.example.com, -t, cd /var/www/example.com/current && bash --login"
+
+
+  Scenario: It opens a remote shell on the selected server
+    Given a file named "config/deploy.rb" with "deploy.rb exists"
+    And a file named "config/deploy/geordi.rb" with:
+    """
+    set :user, 'deploy'
+    set :deploy_to, '/var/www/example.com'
+    server 'first.example.com'
+    server 'second.example.com'
+    """
+
+    When I run `geordi shell geordi --select-server 1`
+    Then the output should contain "Util.system! ssh, deploy@first.example.com, -t, cd /var/www/example.com/current && bash --login"
+
+    When I run `geordi shell geordi -s2`
+    Then the output should contain "Util.system! ssh, deploy@second.example.com, -t, cd /var/www/example.com/current && bash --login"
+
+
+  Scenario: It prints a warning and opens a menu to select the server to connect to when the server number is invalid
+    Given a file named "config/deploy.rb" with "deploy.rb exists"
+    And a file named "config/deploy/geordi.rb" with:
+    """
+    set :user, 'deploy'
+    set :deploy_to, '/var/www/example.com'
+    server 'first.example.com'
+    server 'second.example.com'
+    """
+
+    When I run `geordi shell geordi -s foo` interactively
+      # Answer prompt "Connect to? [1]"
+      And I type "2"
+    Then the output should contain "> Invalid server number: foo"
+    Then the output should contain "Util.system! ssh, deploy@second.example.com, -t, cd /var/www/example.com/current && bash --login"
+
+    When I run `geordi shell geordi -s5` interactively
+      # Answer prompt "Connect to? [1]"
+      And I type "1"
+    Then the output should contain "> Invalid server number: 5"
     Then the output should contain "Util.system! ssh, deploy@first.example.com, -t, cd /var/www/example.com/current && bash --login"
 
 

--- a/lib/geordi/commands/console.rb
+++ b/lib/geordi/commands/console.rb
@@ -3,10 +3,18 @@ long_desc <<-LONGDESC
 Open a local Rails console: `geordi console`
 
 Open a Rails console on `staging`: `geordi console staging`
+
+Lets you select the server to connect to from a menu when called with `--select-server` or the alias `-s`:
+
+    geordi console staging -s
+
+If you already know the number of the server you want to connect to, just pass it along:
+
+    geordi console staging -s2
 LONGDESC
 
 
-option :select_server, default: false, type: :boolean, aliases: '-s'
+option :select_server, type: :string, aliases: '-s'
 
 def console(target = 'development', *_args)
   require 'geordi/remote'

--- a/lib/geordi/commands/dump.rb
+++ b/lib/geordi/commands/dump.rb
@@ -21,7 +21,7 @@ dump into the development database after downloading it.
 DESC
 
 option :load, aliases: ['-l'], type: :string, desc: 'Load a dump'
-option :select_server, default: false, type: :boolean, aliases: '-s'
+option :select_server, type: :string, aliases: '-s'
 
 def dump(target = nil, *_args)
   require 'geordi/dump_loader'

--- a/lib/geordi/commands/dump.rb
+++ b/lib/geordi/commands/dump.rb
@@ -21,7 +21,6 @@ dump into the development database after downloading it.
 DESC
 
 option :load, aliases: ['-l'], type: :string, desc: 'Load a dump'
-option :select_server, type: :string, aliases: '-s'
 
 def dump(target = nil, *_args)
   require 'geordi/dump_loader'

--- a/lib/geordi/commands/shell.rb
+++ b/lib/geordi/commands/shell.rb
@@ -2,12 +2,16 @@ desc 'shell TARGET', 'Open a shell on a Capistrano deploy target'
 long_desc <<-LONGDESC
 Example: `geordi shell production`
 
-Lets you select the server to connect to when called with `--select-server`:
+Lets you select the server to connect to from a menu when called with `--select-server` or the alias `-s`:
 
     geordi shell production -s
+
+If you already know the number of the server you want to connect to, just pass it along:
+
+    geordi shell production -s2
 LONGDESC
 
-option :select_server, default: false, type: :boolean, aliases: '-s'
+option :select_server, type: :string, aliases: '-s'
 
 # This method has a triple 'l' because :shell is a Thor reserved word. However,
 # it can still be called with `geordi shell` :)

--- a/lib/geordi/remote.rb
+++ b/lib/geordi/remote.rb
@@ -34,7 +34,6 @@ module Geordi
       # Generate dump on the server
       shell options.merge({
         remote_command: "dumple #{@config.env} --for_download",
-        select_server: nil, # Dump must be generated on the primary server
       })
 
       destination_directory = File.join(@config.root, 'tmp')

--- a/lib/geordi/remote.rb
+++ b/lib/geordi/remote.rb
@@ -56,7 +56,20 @@ module Geordi
     end
 
     def shell(options = {})
-      server = options[:select_server] ? select_server : @config.primary_server
+      server_option = options[:select_server]
+      server_number = server_option.to_i
+
+      server =  if server_option == 'select_server'
+        select_server
+      elsif server_number != 0 && server_number <= @config.servers.count
+        server_index = server_number - 1
+        @config.servers[server_index]
+      elsif server_option.nil?
+        @config.primary_server
+      else
+        Interaction.warn "Invalid server number: #{server_option}"
+        select_server
+      end
 
       remote_command = "cd #{@config.remote_root} && #{@config.shell}"
       remote_command << " -c '#{options[:remote_command]}'" if options[:remote_command]


### PR DESCRIPTION
…menu (closes #43)

The server number can now be passed to the `--select-server` option for the `geordi shell` and `geordi console` commands to connect directly to the server, e.g. `geordi shell staging --select-server 2`.
Thereby the server select menu will be skipped.
The alias `-s` can still be used.
The server select menu will open as usual with a command like `geordi shell staging --select-server`.