### PR TITLE
adding an option for supporting multiple databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,17 @@ offer to edit the whitelist instead.
 - `[--postgres=PORT_OR_SOCKET]`: Use Postgres port or socket
 - `[--mysql=PORT_OR_SOCKET]`: Use MySQL/MariaDB port or socket
 
-
 ### `geordi dump [TARGET]`
 Handle (remote) database dumps.
+
+If you are using multiple databases per environment, pass the database name like this:
+
+    geordi dump -d primary
+
+Loading a dump into one of multiple local databases is not supported yet.
+
+When called with the `--load` option, sources the specified dump into the
+development database.
 
 `geordi dump` (without arguments) dumps the development database with `dumple`.
 
@@ -407,7 +415,7 @@ To try Geordi locally, call it like this:
 
     # -I means "add the following directory to load path"
     ruby -Ilib exe/geordi
-    
+
     # From another directory
     ruby -I ../geordi/lib ../geordi/exe/geordi
 

--- a/exe/dumple
+++ b/exe/dumple
@@ -48,7 +48,10 @@ begin
   environment, database = ARGV.reject{ |arg| arg[0].chr == '-' }
   environment ||= 'production'
   config = config[environment] or raise "No #{environment} database found.\nUsage: dumple ENVIRONMENT [DATABASE]"
-  config = config[database] if database
+
+  if database
+    config = config[database] or raise %(Unknown #{environment} database "#{database}")
+  end
 
   dump_dir = "#{ENV['HOME']}/dumps"
   unless File.directory?(dump_dir)
@@ -62,7 +65,7 @@ begin
     dump_path = "#{dump_dir}/#{config['database']}_#{Time.now.strftime("%Y%m%d_%H%M%S")}.dump"
   end
 
-  puts "> Dumping database for \"#{environment}\" environment ..."
+  puts "> Dumping \"#{config['database'] + ' '}\"database for \"#{environment}\" environment ..."
 
   host = config['host']
   port = config['port']

--- a/exe/dumple
+++ b/exe/dumple
@@ -45,9 +45,10 @@ begin
   end
 
   config = YAML::load(ERB.new(File.read(config_path)).result)
-
-  environment = ARGV.reject{ |arg| arg[0].chr == '-' }.first || 'production'
-  config = config[environment] or raise "No #{environment} database found.\nUsage: dumple ENVIRONMENT"
+  environment, database = ARGV.reject{ |arg| arg[0].chr == '-' }
+  environment ||= 'production'
+  config = config[environment] or raise "No #{environment} database found.\nUsage: dumple ENVIRONMENT [DATABASE]"
+  config = config[database] if database
 
   dump_dir = "#{ENV['HOME']}/dumps"
   unless File.directory?(dump_dir)

--- a/exe/dumple
+++ b/exe/dumple
@@ -65,7 +65,8 @@ begin
     dump_path = "#{dump_dir}/#{config['database']}_#{Time.now.strftime("%Y%m%d_%H%M%S")}.dump"
   end
 
-  puts "> Dumping \"#{config['database'] + ' '}\"database for \"#{environment}\" environment ..."
+  given_database = database ? %(#{database} ) : ""
+  puts "> Dumping #{given_database}database for \"#{environment}\" environment ..."
 
   host = config['host']
   port = config['port']

--- a/features/dump.feature
+++ b/features/dump.feature
@@ -6,6 +6,10 @@ Feature: The dump command
     Then the output should contain "Util.run! dumple development"
       And the output should contain "Successfully dumped the development database"
 
+  Scenario: Creating a dump of the development database with multiple databases
+    When I run `geordi dump -d primary`
+    Then the output should contain "Util.system! dumple development primary"
+      And the output should contain "Successfully dumped the primary development database"
 
   Scenario: Creating a dump of a remote database
     Given a file named "Capfile" with "Capfile exists"
@@ -32,3 +36,74 @@ Feature: The dump command
       Util\.run! scp -C user@www\.example\.com:~\/dumps\/dump_for_download.dump .*?\/tmp\/aruba\/tmp\/staging.dump
       """
       And the output should contain "> Dumped the staging database to tmp/staging.dump"
+
+  Scenario: Creating a dump of a remote database and loading it locally
+    Given a file named "Capfile" with "Capfile exists"
+    And a file named "config/deploy.rb" with "deploy.rb exists"
+    And a file named "config/deploy/staging.rb" with:
+    """
+    set :rails_env, 'staging'
+    set :deploy_to, '/var/www/example.com'
+    set :user, 'user'
+
+    server 'www.example.com'
+    """
+    And a file named "config/database.yml" with:
+    """
+    development:
+      database: test
+      adapter: postgresql
+    """
+
+    When I run `geordi dump staging --load`
+      Then the output should contain "# Dumping the database of staging"
+        And the output should contain "Util.system! ssh, user@www.example.com, -t, cd /var/www/example.com/current && bash --login -c 'dumple staging --for_download'"
+        And the output should contain "> Dumped the staging database to tmp/staging.dump"
+
+        # Loading the dump
+        And the output should contain "Sourcing dump into the test db"
+        And the output should contain "Your test database has now the data of staging."
+
+  Scenario: Creating a dump of one of multiple remote databases
+    Given a file named "Capfile" with "Capfile exists"
+    And a file named "config/deploy.rb" with "deploy.rb exists"
+    And a file named "config/deploy/staging.rb" with:
+    """
+    set :rails_env, 'staging'
+    set :deploy_to, '/var/www/example.com'
+    set :user, 'user'
+
+    server 'www.example.com'
+    """
+
+    When I run `geordi dump staging --database primary`
+    Then the output should contain "# Dumping the database of staging (primary database)"
+      And the output should contain "Util.system! ssh, user@www.example.com, -t, cd /var/www/example.com/current && bash --login -c 'dumple staging primary --for_download'"
+      And the output should contain "> Dumped the primary staging database to tmp/staging.dump"
+
+  Scenario: Creating a dump of one of multiple remote databases and loading it locally
+    Given a file named "Capfile" with "Capfile exists"
+    And a file named "config/deploy.rb" with "deploy.rb exists"
+    And a file named "config/deploy/staging.rb" with:
+    """
+    set :rails_env, 'staging'
+    set :deploy_to, '/var/www/example.com'
+    set :user, 'user'
+
+    server 'www.example.com'
+    """
+    And a file named "config/database.yml" with:
+    """
+    development:
+      database: test
+      adapter: postgresql
+    """
+
+    When I run `geordi dump staging --database primary --load`
+      Then the output should contain "# Dumping the database of staging (primary database)"
+        And the output should contain "Util.system! ssh, user@www.example.com, -t, cd /var/www/example.com/current && bash --login -c 'dumple staging primary --for_download'"
+        And the output should contain "> Dumped the primary staging database to tmp/staging.dump"
+
+        # Loading the dump
+        And the output should contain "Sourcing dump into the test db"
+        And the output should contain "Your test database has now the data of staging (primary database)."

--- a/lib/geordi/commands/dump.rb
+++ b/lib/geordi/commands/dump.rb
@@ -8,15 +8,26 @@ specified dump file into the development database.
 `geordi dump staging` (with a Capistrano deploy target) remotely dumps the
 specified target's database and downloads it to `tmp/`.
 
+If you are using multiple databases per environment, pass the database name like this:
+
+    geordi dump -d primary
+
+Loading a dump into one of multiple local databases is not supported yet.
+
+When called with the `--load` option, sources the specified dump into the
+development database.
+
 `geordi dump staging -l` (with a Capistrano deploy target and the `--load`
 option) sources the dump into the development database after downloading it.
 DESC
 
 option :load, aliases: '-l', type: :string, desc: 'Load a dump', banner: '[DUMP_FILE]'
+option :database, aliases: '-d', type: :string, desc: 'Database name, if there are multiple databases', banner: 'NAME'
 
 def dump(target = nil, *_args)
   require 'geordi/dump_loader'
   require 'geordi/remote'
+  database = options[:database] ? "#{options[:database]} " : ''
 
   if target.nil?
     if options.load
@@ -33,12 +44,14 @@ def dump(target = nil, *_args)
 
     else
       Interaction.announce 'Dumping the development database'
-      Util.run!('dumple development')
-      Interaction.success 'Successfully dumped the development database.'
+      Util.run!("dumple development #{database}")
+      Interaction.success "Successfully dumped the #{database}development database."
     end
 
   else
-    Interaction.announce 'Dumping the database of ' + target
+    database_label = options[:database] ? " (#{database}database)" : ""
+
+    Interaction.announce "Dumping the database of #{target}#{database_label}"
     dump_path = Geordi::Remote.new(target).dump(options)
 
     if options.load
@@ -47,7 +60,7 @@ def dump(target = nil, *_args)
       Interaction.announce "Sourcing dump into the #{loader.config['database']} db"
       loader.load
 
-      Interaction.success "Your #{loader.config['database']} database has now the data of #{target}."
+      Interaction.success "Your #{loader.config['database']} database has now the data of #{target}#{database_label}."
     end
   end
 end

--- a/lib/geordi/commands/dump.rb
+++ b/lib/geordi/commands/dump.rb
@@ -8,17 +8,14 @@ specified dump file into the development database.
 `geordi dump staging` (with a Capistrano deploy target) remotely dumps the
 specified target's database and downloads it to `tmp/`.
 
+`geordi dump staging -l` (with a Capistrano deploy target and the `--load`
+option) sources the dump into the development database after downloading it.
+
 If you are using multiple databases per environment, pass the database name like this:
 
     geordi dump -d primary
 
 Loading a dump into one of multiple local databases is not supported yet.
-
-When called with the `--load` option, sources the specified dump into the
-development database.
-
-`geordi dump staging -l` (with a Capistrano deploy target and the `--load`
-option) sources the dump into the development database after downloading it.
 DESC
 
 option :load, aliases: '-l', type: :string, desc: 'Load a dump', banner: '[DUMP_FILE]'

--- a/lib/geordi/remote.rb
+++ b/lib/geordi/remote.rb
@@ -31,9 +31,10 @@ module Geordi
     end
 
     def dump(options = {})
+      database = options[:database] ? " #{options[:database]}" : ''
       # Generate dump on the server
       shell options.merge({
-        remote_command: "dumple #{@config.env} --for_download",
+        remote_command: "dumple #{@config.env}#{database} --for_download",
       })
 
       destination_directory = File.join(@config.root, 'tmp')
@@ -45,7 +46,7 @@ module Geordi
       server = @config.primary_server
       Util.run!("scp -C #{@config.user(server)}@#{server}:#{REMOTE_DUMP_PATH} #{destination_path}")
 
-      Interaction.success "Dumped the #{@stage} database to #{relative_destination}."
+      Interaction.success "Dumped the#{database} #{@stage} database to #{relative_destination}."
 
       destination_path
     end


### PR DESCRIPTION
In [this issue](https://github.com/makandra/geordi/issues/101) I am explaining the problem of dumple not finding the right key for the database in a database.yml that has multiple databases. So here is a solution where we like to offer another option to define that key.