### PR TITLE
Remove deprecated executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Improved documentation; README now includes command options.
 
 ### Breaking changes
+- Removed deprecated executables
 
 
 ## 3.2.0 2020-07-15

--- a/exe/cap-all
+++ b/exe/cap-all
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi ca[pistrano]` instead'
-exec 'geordi', 'capistrano', *ARGV

--- a/exe/console-for
+++ b/exe/console-for
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi con[sole]` instead'
-exec 'geordi', 'console', *ARGV

--- a/exe/cuc
+++ b/exe/cuc
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi cu[cumber]` instead'
-exec 'geordi', 'cucumber', *ARGV

--- a/exe/cuc-show
+++ b/exe/cuc-show
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi vn[c]` instead'
-exec 'geordi', 'vnc'

--- a/exe/cuc-vnc-setup
+++ b/exe/cuc-vnc-setup
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi vn[c] --setup` instead'
-exec 'geordi', 'vnc', '--setup'

--- a/exe/deploy-to-production
+++ b/exe/deploy-to-production
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi dep[loy]` instead'
-exec 'geordi', 'deploy'

--- a/exe/dump-for
+++ b/exe/dump-for
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-
-if (i = ARGV.index '-s')
-  ARGV[i] = '-l'
-end
-
-puts 'DEPRECATED: Use `geordi du[mp]` instead'
-exec 'geordi', 'dump', *ARGV

--- a/exe/gitpt
+++ b/exe/gitpt
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi com[mit]` instead'
-exec 'geordi', 'commit'

--- a/exe/load-dump
+++ b/exe/load-dump
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi du[mp] -l` instead'
-exec 'geordi', 'dump', '-l', *ARGV

--- a/exe/migrate-all
+++ b/exe/migrate-all
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi m[igrate]` instead'
-exec 'geordi', 'migrate'

--- a/exe/rs
+++ b/exe/rs
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi rs[pec]` instead'
-exec 'geordi', 'rspec', *ARGV

--- a/exe/run_tests
+++ b/exe/run_tests
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi f[irefox]` instead'
-exec 'geordi', 'firefox', *ARGV

--- a/exe/shell-for
+++ b/exe/shell-for
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi sh[ell]` instead'
-exec 'geordi', 'shell', *ARGV

--- a/exe/tests
+++ b/exe/tests
@@ -1,4 +1,0 @@
-#!/usr/bin/env ruby
-
-puts 'DEPRECATED: Use `geordi t[est]` instead'
-exec 'geordi', 'test'

--- a/geordi.gemspec
+++ b/geordi.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.post_install_message = <<-ATTENTION
 * Binary `geordi` installed
+* Geordi 4.0.0 has removed its deprecated executables. If you want to invoke these commands like before, you may create aliases on your machine. For the alias mapping, please refer to https://github.com/makandra/geordi/commit/68fa92acb146ebde3acb92d7b9556bd4eaa2b4ff
   ATTENTION
 end


### PR DESCRIPTION
Removes the executables `cap-all`, `console-for`, `cuc`, `cuc-show`, `cuc-vnc-setup`, `deploy-to-production`, `dump-for`, `gitpt`, `load-dump`, `migrate-all`, `rs`, `run_tests` ,`shell-for` and `tests`.
