### PR TITLE
add dumple option `--compress` to compress after dumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 ### Compatible changes
+- Added dumple option `--compress` to compress after dumping
 ### Breaking changes
 
 

--- a/exe/dumple
+++ b/exe/dumple
@@ -3,6 +3,7 @@
 require 'erb'
 
 fail_gently = ARGV.include?("--fail-gently")
+compress = ARGV.include?("--compress")
 
 if ARGV.include?("-i")
   puts "*******************************************************"
@@ -95,6 +96,15 @@ begin
   success or raise "Creating the dump failed"
 
   system "chmod 600 #{dump_path}"
+
+  if compress
+    puts "> Compressing the dump ..."
+
+    # gzip compresses in place
+    compress_success = system("gzip #{dump_path}")
+    compress_success or raise "Compressing the dump failed"
+    dump_path << ".gz"
+  end
 
   dump_size_kb = (File.size(dump_path) / 1024).round
 


### PR DESCRIPTION
In almost all projects we have a capistrano hook to dump the database with dumple during migrations. As dumps might use a lot of disk space it would be nice to have those dumps compressed. 