### PR TITLE
added chromedriver update to cucumber command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   ```
 
 ### Compatible changes
+
+* added `auto_update_chromedriver` as global setting option to automatically update chromedriver before cucumber 
+  tests, if Chrome and chromedriver versions don't match. 
 ### Breaking changes
 
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Example: `geordi chromedriver_update`
 This command will find and install the matching chromedriver for the currently
 installed Chrome.
 
+Setting `auto_update_chromedriver` to `true` in your global Geordi config file 
+(`~/.config/geordi/global.yml`), will automatically update chromedriver before 
+cucumber tests, in case Chrome and chromedriver versions don't match
+
+**Options**
+- `[--quiet-if-matching], [--no-quiet-if-matching]`: Suppress notification if chromedriver and chrome versions match
+
 
 ### `geordi clean`
 Remove unneeded files from the current directory.

--- a/lib/geordi/commands/chromedriver_update.rb
+++ b/lib/geordi/commands/chromedriver_update.rb
@@ -4,6 +4,10 @@ Example: `geordi chromedriver_update`
 
 This command will find and install the matching chromedriver for the currently
 installed Chrome.
+
+Setting `auto_update_chromedriver` to `true` in your global Geordi config file 
+(`~/.config/geordi/global.yml`), will automatically update chromedriver before 
+cucumber tests, in case Chrome and chromedriver versions don't match
 LONGDESC
 
 option :quiet_if_matching, type: :boolean, default: false,

--- a/lib/geordi/commands/cucumber.rb
+++ b/lib/geordi/commands/cucumber.rb
@@ -55,7 +55,9 @@ def cucumber(*args)
 
     invoke_geordi 'bundle_install'
     invoke_geordi 'yarn_install'
-    invoke_geordi 'chromedriver_update', quiet_if_matching: true
+    if settings.auto_update_chromedriver
+      invoke_geordi 'chromedriver_update', quiet_if_matching: true
+    end
 
     cmd_opts, files = args.partition { |f| f.start_with? '-' }
     cmd_opts << '--format' << 'pretty' << '--backtrace' if options.debug

--- a/lib/geordi/settings.rb
+++ b/lib/geordi/settings.rb
@@ -8,7 +8,7 @@ module Geordi
     GLOBAL_SETTINGS_FILE_NAME = Util.testing? ? './tmp/global_settings.yml'.freeze : File.join(ENV['HOME'], '.config/geordi/global.yml').freeze
     LOCAL_SETTINGS_FILE_NAME = Util.testing? ? './tmp/local_settings.yml'.freeze : './.geordi.yml'.freeze
 
-    ALLOWED_GLOBAL_SETTINGS = %w[ pivotal_tracker_api_key ].freeze
+    ALLOWED_GLOBAL_SETTINGS = %w[ pivotal_tracker_api_key auto_update_chromedriver ].freeze
     ALLOWED_LOCAL_SETTINGS = %w[ use_vnc pivotal_tracker_project_ids ].freeze
 
     def initialize
@@ -22,6 +22,15 @@ module Geordi
 
     def pivotal_tracker_api_key=(value)
       @global_settings['pivotal_tracker_api_key'] = value
+      save_global_settings
+    end
+
+    def auto_update_chromedriver
+      @global_settings["auto_update_chromedriver"] || false
+    end
+
+    def auto_update_chromedriver=(value)
+      @global_settings['auto_update_chromedriver'] = value
       save_global_settings
     end
 


### PR DESCRIPTION
The duration of the update_chromedriver command (if installation is skipped) is between 133 and 140ms (measured with `time`  bash command). Without checking for version equality it was about 116 to 118 ms, so the equality check takes about 20ms 