### PR TITLE
Fix filename corruption bug of geordi cucumber --modified (closes #115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+- Fixed #115: `geordi cucumber --modified` command, that corrupts filenames like:
+  ```
+  No such file or directory tures/pages.feature
+  ```
+  Also required the `English` gem, for correct usage of global variables
+
 ### Compatible changes
 ### Breaking changes
 

--- a/lib/geordi/cli.rb
+++ b/lib/geordi/cli.rb
@@ -2,7 +2,6 @@ require 'thor'
 require 'bundler'
 require 'geordi/interaction'
 require 'geordi/util'
-require 'English'
 
 module Geordi
   class CLI < Thor

--- a/lib/geordi/cli.rb
+++ b/lib/geordi/cli.rb
@@ -2,6 +2,7 @@ require 'thor'
 require 'bundler'
 require 'geordi/interaction'
 require 'geordi/util'
+require 'English'
 
 module Geordi
   class CLI < Thor

--- a/lib/geordi/commands/cucumber.rb
+++ b/lib/geordi/commands/cucumber.rb
@@ -37,7 +37,7 @@ def cucumber(*args)
   if args.empty?
     # This is not testable as there is no way to stub `git` :(
     if options.modified?
-      modified_features = `git status --short`.split($INPUT_RECORD_SEPARATOR).map do |line|
+      modified_features = `git status --short`.split("\n").map do |line|
         indicators = line.slice!(0..2) # Remove leading indicators
         line if line.include?('.feature') && !indicators.include?('D')
       end.compact
@@ -45,7 +45,7 @@ def cucumber(*args)
     end
 
     if options.containing
-      matching_features = `grep -lri '#{options.containing}' --include=*.feature features/`.split($INPUT_RECORD_SEPARATOR)
+      matching_features = `grep -lri '#{options.containing}' --include=*.feature features/`.split("\n")
       args = matching_features.uniq
     end
   end


### PR DESCRIPTION
Fixed that `geordi cucumber --modified` corrupts the filename and cuts off `fea` of `feature`, which results in errors like:
```
No such file or directory tures/pages.feature
```

Also required the `English` gem, for correct (future) usage of global variables, like `$INPUT_RECORD_SEPARATOR`.
For reasons of consistency, however, this variable was replaced with `"\n"`.