### PR TITLE
[#124] Add tightvnc compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install vncserver
       run: |
         sudo apt-get update
-        sudo apt-get install -y vnc4server
+        sudo apt-get install -y tightvncserver
         # Fake required password for vncserver
         mkdir ~/.vnc && touch ~/.vnc/passwd && chmod 700 ~/.vnc/passwd
     - name: Bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
+* Switch to tightvncserver to be compatible with Ubuntu 20.04. vnc4server is still supported.
+
 ### Breaking changes
 
 

--- a/lib/geordi/commands/_setup_vnc.rb
+++ b/lib/geordi/commands/_setup_vnc.rb
@@ -23,25 +23,23 @@ def _setup_vnc
     Interaction.success 'It appears you already have a VNC server installed. Good job!'
   else
     puts 'Please run:'
-    Interaction.note_cmd 'sudo apt-get install vnc4server'
+    Interaction.note_cmd 'sudo apt-get install tightvncserver'
+    puts 'In case this package is not available, you may try vnc4server instead.'
     Interaction.prompt 'Continue ...'
 
     puts
+
     Interaction.note 'We will now set a password for your VNC server.'
     puts Util.strip_heredoc <<-TEXT
-      When running our cucumber script, you will not actually need this
-      password, and there is no security risk. However, if you start a vncserver
-      without our cucumber script, a user with your password can connect to
-      your machine.
+      When running our cucumber script, this password will be used while also
+      restricting access to the local machine. However, if you start a vncserver
+      without our cucumber script, keep in mind that a user with this password
+      can connect to your machine.
 
     TEXT
     puts 'Please run:'
-    Interaction.note_cmd 'vncserver :20'
+    Interaction.note_cmd 'vncpasswd'
     Interaction.warn 'Enter a secure password!'
-    Interaction.prompt 'Continue ...'
-
-    puts 'Now stop the server again. Please run:'
-    Interaction.note_cmd 'vncserver -kill :20'
     Interaction.prompt 'Continue ...'
   end
 

--- a/lib/geordi/cucumber.rb
+++ b/lib/geordi/cucumber.rb
@@ -11,8 +11,9 @@ module Geordi
   class Cucumber
 
     VNC_DISPLAY = ':17'.freeze
-    VNC_SERVER_COMMAND = "vncserver #{VNC_DISPLAY} -localhost -nolisten tcp -SecurityTypes None -geometry 1280x1024".freeze
-    VNC_VIEWER_COMMAND = "vncviewer #{VNC_DISPLAY}".freeze
+    VNC_PASSWORD_FILE = File.absolute_path('~/.vnc/passwd').freeze # default for "vncpasswd"
+    VNC_SERVER_COMMAND = "vncserver #{VNC_DISPLAY} -localhost -nolisten tcp -geometry 1280x1024 -rfbauth #{VNC_PASSWORD_FILE}".freeze
+    VNC_VIEWER_COMMAND = "vncviewer #{VNC_DISPLAY} -passwd #{VNC_PASSWORD_FILE}".freeze
     VNC_ENV_VARIABLES = %w[DISPLAY BROWSER LAUNCHY_BROWSER].freeze
 
     def run(files, cucumber_options, options = {})


### PR DESCRIPTION
This commit switches from a "no auth" attempt to using a hardcoded
VNC password. This is neccessary to support both vnc4server and
tightvncserver.

The file `lib/geordi/vnc_password.txt` was created using `vncpasswd`

Fixes https://github.com/makandra/geordi/issues/124