### PR TITLE
Ignore ACL when importing a postgres dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+* Ignore ACL settings when loading a PostgreSQL dump
+
 ### Breaking changes
 
 ## 5.2.1 2020-12-15

--- a/features/dump.feature
+++ b/features/dump.feature
@@ -107,3 +107,33 @@ Feature: The dump command
         # Loading the dump
         And the output should contain "Sourcing dump into the test db"
         And the output should contain "Your test database has now the data of staging (primary database)."
+
+  Scenario: Sourcing a dump with mysql
+    Given a file named "tmp/production.dump" with "some content"
+    And a file named "config/database.yml" with:
+      """
+      development:
+        database: test
+        adapter: mysql
+      """
+
+    When I run `geordi dump -l tmp/production.dump`
+    Then the output should contain "Sourcing dump into the test db"
+    And the output should contain "Source file: tmp/production.dump"
+    And the output should contain "Util.run! mysql --silent --default-character-set=utf8 test < tmp/production.dump"
+    And the output should contain "Your test database has now the data of tmp/production.dump."
+
+  Scenario: Sourcing a dump with postgres
+    Given a file named "tmp/production.dump" with "some content"
+      And a file named "config/database.yml" with:
+      """
+      development:
+        database: test
+        adapter: postgresql
+      """
+
+    When I run `geordi dump -l tmp/production.dump`
+    Then the output should contain "Sourcing dump into the test db"
+      And the output should contain "Source file: tmp/production.dump"
+      And the output should contain "Util.run! pg_restore --no-owner --clean --no-acl --dbname=test tmp/production.dump"
+      And the output should contain "Your test database has now the data of tmp/production.dump."

--- a/lib/geordi/dump_loader.rb
+++ b/lib/geordi/dump_loader.rb
@@ -34,7 +34,7 @@ module Geordi
 
     def postgresql_command
       ENV['PGPASSWORD'] = config['password']
-      command = 'pg_restore --no-owner --clean'
+      command = 'pg_restore --no-owner --clean --no-acl'
       command << ' --username=' << config['username'].to_s if config['username']
       command << ' --port=' << config['port'].to_s if config['port']
       command << ' --host=' << config['host'].to_s if config['host']


### PR DESCRIPTION
Without this settings, pg_dump tried to import the dump to the database
with the name in the dump and not the one specified in the database.yml.

```
pg_restore: [archiver (db)] Error while PROCESSING TOC:
pg_restore: [archiver (db)] Error from TOC entry 3043; 0 0 ACL DATABASE some-application_p postgres
pg_restore: [archiver (db)] could not execute query: ERROR:  database "some-application_p" does not exist
    Command was: REVOKE CONNECT,TEMPORARY ON DATABASE some-application_p FROM PUBLIC;
GRANT TEMPORARY ON DATABASE some-application_p TO PUBLIC;
GRANT ALL ON DATABASE some-application_p TO some-application_p;
GRANT CONNECT ON DATABASE some-application_p TO icinga;
GRANT CONNECT ON DATABASE some-application_p TO monitoring;
```