### PR TITLE
Remove auto-bundling from geordi shell and geordi console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+* Remove auto-bundling from `geordi shell` and remote `geordi console`
+
 ### Breaking changes
 
 

--- a/lib/geordi/commands/console.rb
+++ b/lib/geordi/commands/console.rb
@@ -14,9 +14,9 @@ option :select_server, type: :string, aliases: '-s', banner: '[SERVER_NUMBER]',
 
 def console(target = 'development', *_args)
   require 'geordi/remote'
-  invoke_geordi 'bundle_install'
 
   if target == 'development'
+    invoke_geordi 'bundle_install'
     invoke_geordi 'yarn_install'
 
     Interaction.announce 'Opening a local Rails console'

--- a/lib/geordi/commands/shell.rb
+++ b/lib/geordi/commands/shell.rb
@@ -15,8 +15,6 @@ option :select_server, type: :string, aliases: '-s', banner: '[SERVER_NUMBER]',
 def shelll(target, *_args)
   require 'geordi/remote'
 
-  invoke_geordi 'bundle_install'
-
   Interaction.announce 'Opening a shell on ' + target
   Geordi::Remote.new(target).shell(options)
 end

--- a/lib/geordi/util.rb
+++ b/lib/geordi/util.rb
@@ -1,5 +1,6 @@
 require 'geordi/interaction'
 require 'socket'
+require 'bundler'
 
 module Geordi
   class Util
@@ -167,15 +168,10 @@ module Geordi
       # Get the version for the given gem by parsing Gemfile.lock.
       # Returns nil if the gem is not used.
       def gem_version(gem)
-        # Lines look like `* will_paginate (2.3.15)` or `railslts-version (2.3.18.16 7f51cc7)`
-        bundle_list.split("\n").each do |line|
-          matches = line.match(/\* #{gem} \(([\d\.]+)/)
-          next if matches.nil? || matches[1].nil?
+        lock_file = Bundler::LockfileParser.new(Bundler.read_file(Bundler.default_lockfile))
+        spec = lock_file.specs.detect { |spec| spec.name == gem }
 
-          return Gem::Version.new(matches[1])
-        end
-
-        nil
+        spec && spec.version
       end
 
       def file_containing?(file, regex)
@@ -190,12 +186,6 @@ module Geordi
         leading_whitespace = (string.match(/\A( +)[^ ]+/) || [])[1]
         string.gsub! /^#{leading_whitespace}/, '' if leading_whitespace
         string
-      end
-
-      private
-
-      def bundle_list
-        @bundle_list ||= `bundle list`
       end
 
     end


### PR DESCRIPTION
`geordi console` will still bundle if it is executed locally.
Gem version detection now works without prior bundling.
Closes #136 