### PR TITLE
Allow pivotal tracker projects ids in global config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
+* Allow pivotal tracker ids in the global config file
+
 ### Breaking changes
 
 


### PR DESCRIPTION
Some pivotal tracker projects contain stories for multiply projects (e.g. WeeklyWombat). When working on theses stories it would be nice to use `geordi commit` in all projects without having to edit the local config every time. 