### PR TITLE
Allow `geordi commit` to continue if one of the projects is inaccessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
+* `geordi commit` will continue even if one of the given projects is inaccessible. It will only fail if no stories could be found at all.
 
 ### Breaking changes
 

--- a/features/commit.feature
+++ b/features/commit.feature
@@ -2,6 +2,14 @@ Feature: Creating a git commit from a Pivotal Tracker story
   Background:
     Given a file named "tmp/global_settings.yml" with "pivotal_tracker_api_key: my_api_key"
 
+
+  Scenario: If there are no stories, the command fails
+    Given there are no stories
+
+    When I run `geordi commit`
+    Then the output should contain "No stories to offer."
+
+
   Scenario: Extra arguments are forwarded to "git commit"
     Given I have staged changes
 

--- a/features/step_definitions/miscellaneous_steps.rb
+++ b/features/step_definitions/miscellaneous_steps.rb
@@ -14,8 +14,13 @@ Given /^my local git branches are: (.*)$/ do |branches|
   ENV['GEORDI_TESTING_GIT_BRANCHES'] = branches.split(", ").join("\n") + "\n"
 end
 
+Given 'there are no stories' do
+  ENV['GEORDI_TESTING_NO_PT_STORIES'] = 'true'
+end
+
 After do
   ENV['GEORDI_TESTING_STAGED_CHANGES'] = 'false'
   ENV['GEORDI_TESTING_GIT_USERNAME'] = nil
   ENV['GEORDI_TESTING_GIT_BRANCHES'] = nil
+  ENV['GEORDI_TESTING_NO_PT_STORIES'] = nil
 end


### PR DESCRIPTION
As discussed [here](https://github.com/makandra/geordi/pull/141#issuecomment-776096374).