### PR TITLE
WIP: Exectute MySQL dump as non-blocking transation (closes #142)

### DIFF
--- a/exe/dumple
+++ b/exe/dumple
@@ -78,6 +78,13 @@ begin
     command << " -p\"#{config['password']}\""
     command << " #{config['database']}"
     command << " -r #{dump_path}"
+    # Using a transaction to allow concurrent request while creating a dump.
+    # This works only reliable for InnoDB tables.
+    # More details: https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_single-transaction
+    command << ' --single-transaction'
+    # Disable buffering in memory to avoid a memory overflow for large tables
+    # More details https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_quick
+    command << ' --quick'
     if port
       command << " -h#{host || '127.0.0.1'} -P#{port}"
     else


### PR DESCRIPTION
@jakobscholz  Can you please check if this solves your issue. I was not able to reproduce that tables are locked during the MySQL dump (just some slightly more request times). But maybe this is because my table is to small (`1_487_724` rows; `160.19` MB).

@codener From <https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_single-transaction>, so you know if this could cause issues for us?

> only InnoDB tables are dumped in a consistent state

For the tests I ran on the Rails console following loop:

```
max = {}; loop { max[Time.now.strftime("%d-%m-%Y %H:%M:%S.%3N")] = Benchmark.realtime { Record.first.save! } }
puts max.sort_by {|time, spent| -spent}.first(10)
```

While I started a db dump in another terminal window.

## Output peak before

```
23-02-2021 10:02:15.457
0.2721745010931045
23-02-2021 10:02:15.222
0.23466753587126732
23-02-2021 10:02:15.729
0.21037222887389362
23-02-2021 10:02:15.016
0.20670347288250923
23-02-2021 10:02:14.840
0.17556237988173962
23-02-2021 10:02:14.689
0.15131390700116754
23-02-2021 10:02:14.558
0.1310691419057548
23-02-2021 10:02:14.445
0.11211261618882418
23-02-2021 10:02:14.349
0.09621855895966291
23-02-2021 10:02:14.265
0.08447944791987538
```

## Output peak after

```
23-02-2021 09:56:53.530
0.08606970403343439
23-02-2021 09:56:53.455
0.07486446900293231
23-02-2021 09:56:48.758
0.06692213821224868
23-02-2021 09:56:53.390
0.06529600103385746
23-02-2021 09:56:48.700
0.0578982918523252
23-02-2021 09:56:53.334
0.05593531997874379
23-02-2021 09:56:48.825
0.05191867612302303
23-02-2021 09:56:48.651
0.04961562901735306
23-02-2021 09:56:53.286
0.04807522310875356
23-02-2021 09:56:48.608
0.04284366290085018
```