### PR TITLE
Removed spaces from post install message and clunky console output test.

### DIFF
--- a/features/cucumber.feature
+++ b/features/cucumber.feature
@@ -19,7 +19,7 @@ Feature: The cucumber command
     Then the output should contain "# Running features"
       And the output should contain "> Only: features/single.feature"
       And the output should contain "Features green."
-    But the output should not contain "> Using parallel_tests"
+    But the output should not contain "parallel"
 
 
   Scenario: Multiple features are run in parallel

--- a/geordi.gemspec
+++ b/geordi.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'thor', '~> 1'
 
   spec.post_install_message = <<-ATTENTION
-  Support for sequential running of integration tests tagged with @solo has been dropped.
+Support for sequential running of integration tests tagged with @solo has been dropped.
   ATTENTION
 end


### PR DESCRIPTION
Resolving issues regarding the post install message string and the cucumber.feature:
- The indentation of the post install message string currently prints two spaces verbatim to the terminal.
  - The two spaces should be removed.
- The "should not contain" test in `cucumber.feature:22` is satisfied accidentally if e.g. parallel tests are active but someone changed the output to `> With parallel_tests`.
  - They should make a generic expectation or be removed if obsolete.