### PR TITLE
make `psych` >= 3.1.0 a runtime dependency to use `YAML.safe_load` with keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
+* fix `YAML.safe_load` for `psych` >= 4
 ### Breaking changes
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     geordi (7.0.1)
+      psych (>= 3.1.0)
       thor (~> 1)
 
 GEM
@@ -106,6 +107,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    psych (4.0.1)
     public_suffix (3.1.1)
     rake (12.3.3)
     representable (3.0.4)

--- a/geordi.gemspec
+++ b/geordi.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'thor', '~> 1'
+  spec.add_runtime_dependency 'psych', '>= 3.1.0'
   # Development dependencies are defined in the Gemfile (therefore no `spec.add_development_dependency` directives)
 
   spec.post_install_message = <<-ATTENTION

--- a/lib/geordi/dump_loader.rb
+++ b/lib/geordi/dump_loader.rb
@@ -14,8 +14,15 @@ module Geordi
       require 'yaml'
 
       evaluated_config_file = ERB.new(File.read('config/database.yml')).result
+
       # Allow aliases and a special set of classes like symbols and time objects
-      @config ||= YAML.safe_load(evaluated_config_file, [Symbol, Time], [], true)
+      permitted_classes = [Symbol, Time]
+      @config ||= if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+        YAML.safe_load(evaluated_config_file, permitted_classes: permitted_classes, aliases: true)
+      else
+        YAML.safe_load(evaluated_config_file, permitted_classes, [], true)
+      end
+
       @config['development']
     end
     alias_method :config, :development_database_config


### PR DESCRIPTION
I recently installed geordi 7.0.1 and could not load a dump:

```
geordi dump -l tmp/staging.dump 
Traceback (most recent call last):
	11: from ~/.rbenv/versions/2.6.6/bin/geordi:23:in `<main>'
	10: from ~/.rbenv/versions/2.6.6/bin/geordi:23:in `load'
	 9: from ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/geordi-7.0.1/exe/geordi:7:in `<top (required)>'
	 8: from ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/geordi-7.0.1/lib/geordi/util.rb:14:in `installing_missing_gems'
	 7: from ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/geordi-7.0.1/exe/geordi:12:in `block in <top (required)>'
	 6: from ~.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
	 5: from ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	 4: from ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	 3: from ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	 2: from ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/geordi-7.0.1/lib/geordi/commands/dump.rb:37:in `dump'
	 1: from ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/geordi-7.0.1/lib/geordi/dump_loader.rb:18:in `development_database_config'
~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/psych-4.0.1/lib/psych.rb:323:in `safe_load': wrong number of arguments (given 4, expected 1) (ArgumentError)
```

The problem here is that geordi does not set a psych version and the `YAML.safe_load` syntax changed, which makes `@config ||= YAML.safe_load(evaluated_config_file, [Symbol, Time], [], true)` fail with recent psych versions.

`safe_load` started accepting keyword arguments in version 3.1.0 and dropped support for positional arguments in 4.0.0.
As 3.1.0 was released December 18, 2018 I'd suggest to just use this and newer versions in conjunction with keyword arguments.