### PR TITLE
Change update mechanism of `geordi chromedriver-update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
+* Change the update mechanism of `geordi chromedriver-update`: This command (and `geordi cucumber`/`geordi tests` if the `auto_update_chromedriver` option is active) will now always update to the latest version of chromedriver for the current chrome version.
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ installed Chrome.
 
 Setting `auto_update_chromedriver` to `true` in your global Geordi config file 
 (`~/.config/geordi/global.yml`), will automatically update chromedriver before 
-cucumber tests, in case Chrome and chromedriver versions don't match
+cucumber tests if a newer chromedriver version is available.
 
 **Options**
-- `[--quiet-if-matching], [--no-quiet-if-matching]`: Suppress notification if chromedriver and chrome versions match
+- `[--quiet-if-matching], [--no-quiet-if-matching]`: Suppress notification if chromedriver is already on the latest version
 
 
 ### `geordi clean`

--- a/lib/geordi/commands/chromedriver_update.rb
+++ b/lib/geordi/commands/chromedriver_update.rb
@@ -7,11 +7,11 @@ installed Chrome.
 
 Setting `auto_update_chromedriver` to `true` in your global Geordi config file 
 (`~/.config/geordi/global.yml`), will automatically update chromedriver before 
-cucumber tests, in case Chrome and chromedriver versions don't match
+cucumber tests if a newer chromedriver version is available.
 LONGDESC
 
 option :quiet_if_matching, type: :boolean, default: false,
-  desc: 'Suppress notification if chromedriver and chrome versions match'
+  desc: 'Suppress notification if chromedriver is already on the latest version'
 
 def chromedriver_update
   require 'geordi/chromedriver_updater'


### PR DESCRIPTION
This command (and `geordi cucumber`/`geordi tests` if the `auto_update_chromedriver` option is active) will now always update to the latest version of chromedriver for the current chrome version.