### PR TITLE
use YAML.safe_load in dumple and allow aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
+* Use YAML.safe_load in dumple and allow aliases
 
 ### Breaking changes
 

--- a/exe/dumple
+++ b/exe/dumple
@@ -92,7 +92,11 @@ end
 def find_database_config(config_path, environment, database)
   environment ||= 'production'
   database_yml = ERB.new(File.read(config_path)).result
-  config = YAML::load(database_yml)
+  config = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+    YAML.safe_load(database_yml, aliases: true)
+  else
+    YAML.safe_load(database_yml, [], [], true)
+  end
   config = config[environment] or raise "x No #{environment} database found.\nUsage: dumple ENVIRONMENT [DATABASE]"
 
   if config.values[0].is_a? Hash # Multi-db setup


### PR DESCRIPTION
In v9.1.0 in noticed that the `geordi dump` command fails in projects that include YAML aliases in the database.yml file:

```
g dump

# Dumping the development database
Unknown alias: test

x Something went wrong.
```
`database.yml`:
```
development:
  adapter: postgresql
  encoding: unicode
  host: 127.0.0.1
  database: foo_development

test: &test
  adapter: postgresql
  encoding: unicode
  host: 127.0.0.1
  database: foo_test<%= ENV['TEST_ENV_NUMBER']%>

cucumber:
  <<: *test
```

In my project Psych `v4.0.1` was used. The load method changed, to use `safe_load` instead.
As the psych version is not fixed in geordi, I added a version switch that can cope with new and old versions.