### PR TITLE
Ruby 3.2 compatibility

### DIFF
--- a/exe/b
+++ b/exe/b
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
 call = ARGV.dup
-call = ['bundle', 'exec'] + call if File.exists?('Gemfile')
+call = ['bundle', 'exec'] + call if File.exist?('Gemfile')
 exec *call
-

--- a/exe/dumple
+++ b/exe/dumple
@@ -27,7 +27,7 @@ end
 
 def cd_to_project_root(fail_gently)
   current = Dir.pwd
-  until File.exists?(DB_CONFIG_PATH)
+  until File.exist?(DB_CONFIG_PATH)
     Dir.chdir '..'
     if current == Dir.pwd
       if fail_gently

--- a/lib/geordi/settings.rb
+++ b/lib/geordi/settings.rb
@@ -77,10 +77,10 @@ module Geordi
       global_path = GLOBAL_SETTINGS_FILE_NAME
       local_path = LOCAL_SETTINGS_FILE_NAME
 
-      global_settings = if File.exists?(global_path)
+      global_settings = if File.exist?(global_path)
         YAML.safe_load(File.read(global_path))
       end
-      local_settings = if File.exists?(local_path)
+      local_settings = if File.exist?(local_path)
         YAML.safe_load(File.read(local_path))
       end
 
@@ -88,7 +88,7 @@ module Geordi
       unless ENV[SETTINGS_WARNED]
         check_for_invalid_keys(global_settings, ALLOWED_GLOBAL_SETTINGS, global_path)
         check_for_invalid_keys(local_settings, ALLOWED_LOCAL_SETTINGS, local_path)
-        Interaction.warn "Unsupported config file \".firefox-version\". Please remove it." if File.exists?('.firefox-version')
+        Interaction.warn "Unsupported config file \".firefox-version\". Please remove it." if File.exist?('.firefox-version')
 
         ENV[SETTINGS_WARNED] = 'true'
       end

--- a/lib/geordi/util.rb
+++ b/lib/geordi/util.rb
@@ -80,7 +80,7 @@ module Geordi
       def binstub_or_fallback(executable)
         binstub_file = "bin/#{executable}"
 
-        File.exists?(binstub_file) ? binstub_file : "bundle exec #{executable}"
+        File.exist?(binstub_file) ? binstub_file : "bundle exec #{executable}"
       end
 
       def console_command(environment)


### PR DESCRIPTION
`File.exists?` has been deprecated since Ruby 2.1 and removed in 3.2. It was only an alias for `File.exist?` anyway.