### PR TITLE
Improve/fix interrupt handling in locale Rails console

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,19 +399,25 @@ Adding a new command
 ---------------
 
 Copy `lib/geordi/COMMAND_TEMPLATE` to `lib/geordi/commands/your_command` and
-edit it to do what you need it to do. Please add a feature test for the new
-command; see features/ for inspiration.
+edit it to do what you need it to do. Please add appropriate tests for the new
+command; see existing tests for inspiration.
 
-To try Geordi locally, call it like this:
 
-    # -I means "add the following directory to load path"
-    ruby -Ilib exe/geordi
+Running Geordi locally
+----------------------
+
+To run Geordi without installation, call it like this:
+
+    ruby -I lib exe/geordi
 
     # From another directory
     ruby -I ../geordi/lib ../geordi/exe/geordi
 
     # With debugger
-    ruby -r byebug -I ../geordi/lib ../geordi/exe/geordi
+    ruby -r byebug -I lib exe/geordi
+
+    # Have rbenv boot Geordi in the current Ruby version
+    RBENV_VERSION=$(<.ruby-version) ruby -I lib exe/geordi
 
 You can also *install* Geordi locally from its project directory with
 `rake install`. Make sure to switch to the expected Ruby version before.

--- a/README.md
+++ b/README.md
@@ -410,14 +410,14 @@ To run Geordi without installation, call it like this:
 
     ruby -I lib exe/geordi
 
-    # From another directory
-    ruby -I ../geordi/lib ../geordi/exe/geordi
-
     # With debugger
     ruby -r byebug -I lib exe/geordi
 
-    # Have rbenv boot Geordi in the current Ruby version
-    RBENV_VERSION=$(<.ruby-version) ruby -I lib exe/geordi
+    # From another directory
+    ruby -I ../geordi/lib ../geordi/exe/geordi
+
+    # Run Geordi with the Ruby version of that other directory
+    RBENV_VERSION=$(<.ruby-version) ruby -I ../geordi/lib ../geordi/exe/geordi
 
 You can also *install* Geordi locally from its project directory with
 `rake install`. Make sure to switch to the expected Ruby version before.

--- a/features/console.feature
+++ b/features/console.feature
@@ -5,7 +5,7 @@ Feature: The console command
     Given the irb version is "1.1.0"
     When I run `geordi console`
     Then the output should contain "# Opening a local Rails console"
-      And the output should contain "Util.run! bundle exec rails console -e development"
+      And the output should contain "Util.run! (exec) bundle exec rails console -e development"
       But the output should not contain "nomultiline"
 
 
@@ -13,7 +13,7 @@ Feature: The console command
     Given the Ruby version is "3.0"
     When I run `geordi console`
     Then the output should contain "# Opening a local Rails console"
-      And the output should contain "Util.run! bundle exec rails console -e development"
+      And the output should contain "Util.run! (exec) bundle exec rails console -e development"
       But the output should not contain "nomultiline"
 
 
@@ -22,7 +22,7 @@ Feature: The console command
       And the Ruby version is "2.9"
     When I run `geordi console`
     Then the output should contain "# Opening a local Rails console"
-      And the output should contain "Util.run! bundle exec rails console -e development -- --nomultiline"
+      And the output should contain "Util.run! (exec) bundle exec rails console -e development -- --nomultiline"
       And the output should contain "Using --nomultiline switch for faster pasting"
 
 

--- a/lib/geordi/commands/console.rb
+++ b/lib/geordi/commands/console.rb
@@ -28,7 +28,8 @@ def console(target = 'development', *_args)
     Interaction.announce 'Opening a local Rails console'
 
     command = Util.console_command(target)
-    Util.run!(command)
+    # Exec has better behavior on Ctrl + C
+    Util.run!(command, exec: true)
   else
     Interaction.announce 'Opening a Rails console on ' + target
 

--- a/lib/geordi/commands/delete_dumps.rb
+++ b/lib/geordi/commands/delete_dumps.rb
@@ -1,4 +1,4 @@
-desc 'delete-dumps [DIRECTORY]', 'Delete database dump files (*.dump)'
+desc 'delete-dumps [DIRECTORY]', 'Help deleting database dump files (*.dump)'
 long_desc <<-LONGDESC
 Example: `geordi delete-dumps` or `geordi delete-dumps ~/tmp/dumps`
 


### PR DESCRIPTION
Previously, hitting Ctrl + C in a Rails console started by `geordi console`, the shell would get stuck between bash and console, effectively broken. By using `exec` instead of `system`, this can be fixed without having to implement SIGINT handling in Geordi.

See story #186280123.