### PR TITLE
Document how to change the CLI editor used by geordi

### DIFF
--- a/lib/geordi/util.rb
+++ b/lib/geordi/util.rb
@@ -137,14 +137,15 @@ module Geordi
         end
       end
 
-      # try to guess user's favorite cli text editor
       def decide_texteditor
-        %w[/usr/bin/editor vi].each do |texteditor|
-          if cmd_exists?(texteditor) && texteditor.start_with?('$')
-            return ENV[texteditor[1..-1]]
-          elsif cmd_exists? texteditor
-            return texteditor
-          end
+        texteditor = %w[/usr/bin/editor vi].detect do |texteditor|
+          cmd_exists?(texteditor)
+        end
+
+        if texteditor
+          return texteditor
+        else
+          raise "Could not determine you favorite CLI text editor. Use `sudo update-alternatives --config editor` to set your preference."
         end
       end
 


### PR DESCRIPTION
I was surprised that `geordi drop-databases` uses `nano`, while my `$EDITOR` is set to `vim`.

Looking at geordis source code did not help me at first, but I found the solution to my problem in a PR description. With this patch it should be slightly easier for the next person. The `raise` branch is unlikely to be ever evaluated on a standard unix machine.