### PR TITLE
Use branch name for geordi commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
+* `geordi commit` will now auto-suggest a matching issue based on the current branch
 
 ### Breaking changes
 

--- a/features/commit.feature
+++ b/features/commit.feature
@@ -18,6 +18,19 @@ Feature: Creating a git commit from a Linear issue
     And I type ""
     Then the output should contain "Util.run! git, commit, --allow-empty, -m, [team-123] Test Issue, -m, Issue: https://www.issue-url.com"
 
+  Scenario: It uses the current branch to preselect an issue
+    Given the current branch matches an issue
+
+    When I run `geordi commit` interactively
+
+    # Accept the prompt
+    And I type ""
+    # No optional message
+    And I type ""
+
+    Then the output should contain "Auto-detected issue [team-123] Test Issue from branch name."
+      And the output should contain "Use it? [y]"
+      And the output should contain "Util.run! git, commit, --allow-empty, -m, [team-123] Test Issue"
 
   Scenario: Extra arguments are forwarded to "git commit"
     Given I have staged changes

--- a/features/step_definitions/miscellaneous_steps.rb
+++ b/features/step_definitions/miscellaneous_steps.rb
@@ -26,6 +26,10 @@ Given 'there are no Linear issues' do
   ENV['GEORDI_TESTING_NO_LINEAR_ISSUES'] = 'true'
 end
 
+Given 'the current branch matches an issue' do
+  ENV['GEORDI_TESTING_ISSUE_MATCHES'] = 'true'
+end
+
 After do
   ENV['GEORDI_TESTING_STAGED_CHANGES'] = 'false'
   ENV['GEORDI_TESTING_GIT_BRANCHES'] = nil
@@ -33,4 +37,5 @@ After do
   ENV['GEORDI_TESTING_IRB_VERSION'] = nil
   ENV['GEORDI_TESTING_RUBY_VERSION'] = nil
   ENV['GEORDI_TESTING_DEFAULT_BRANCH'] = nil
+  ENV['GEORDI_TESTING_ISSUE_MATCHES'] = nil
 end


### PR DESCRIPTION
This change allows `geordi commit` to read the name of the current branch and auto-select an issue that matches the current branch name.