### PR TITLE
Improve issue ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Compatible changes
+* `geordi branch` and `geordi commit` will now order the list of suggested issues by team
 
 ### Breaking changes
 

--- a/lib/geordi/linear_client.rb
+++ b/lib/geordi/linear_client.rb
@@ -39,7 +39,8 @@ module Geordi
       if issues.empty?
         Geordi::Interaction.fail('No issues to offer.')
       end
-      issues.sort_by! { |i| -i.dig('state', 'position') }
+      team_ids = settings.linear_team_ids
+      issues.sort_by! { |i| [team_ids.index(i.dig('team', 'id')), -i.dig('state', 'position')] }
 
       highline.choose do |menu|
         max_label_length = 60


### PR DESCRIPTION
Currently, the issue list printed by `geordi branch` and `geordi commit` interleaves issues in different teams, leading to lists like
```
1. [A-123]
2. [A-124]
3. [B-12]
4. [A-130]
5. [B-13]
6. [A-131]
```

Even when multiple teams are configured, I usually know which team the issue I want to select belongs to. Sorting the list by team then state would allow me to limit my search to the relevant section of the list.