### PR TITLE
do not add Linear URL to commit message

### DIFF
--- a/features/commit.feature
+++ b/features/commit.feature
@@ -10,14 +10,6 @@ Feature: Creating a git commit from a Linear issue
     Then the output should contain "No issues to offer."
 
 
-  Scenario: It creates a commit with the linear issue url as description
-    Given I have staged changes
-
-    When I run `geordi commit` interactively
-      # No optional message
-    And I type ""
-    Then the output should contain "Util.run! git, commit, --allow-empty, -m, [team-123] Test Issue, -m, Issue: https://www.issue-url.com"
-
   Scenario: It uses the current branch to preselect an issue
     Given the current branch matches an issue
 
@@ -39,7 +31,7 @@ Feature: Creating a git commit from a Linear issue
     When I run `geordi commit --extra-option` interactively
       # No optional message
       And I type ""
-    Then the output should contain "Util.run! git, commit, --allow-empty, -m, [team-123] Test Issue, -m, Issue: https://www.issue-url.com, --extra-option"
+    Then the output should contain "Util.run! git, commit, --allow-empty, -m, [team-123] Test Issue, --extra-option"
 
 
   Scenario: With no staged changes, a warning is printed

--- a/lib/geordi/commands/commit.rb
+++ b/lib/geordi/commands/commit.rb
@@ -22,10 +22,9 @@ def commit(*git_args)
 
   issue = linear_client.issue_from_branch || linear_client.choose_issue
   title = "[#{issue['identifier']}] #{issue['title']}"
-  description = "Issue: #{issue['url']}"
   extra = highline.ask("\nAdd an optional message").strip
   title << ' - ' << extra if extra != ''
-  Util.run!(['git', 'commit', '--allow-empty', '-m', title, '-m', description, *git_args])
+  Util.run!(['git', 'commit', '--allow-empty', '-m', title, *git_args])
 
   Hint.did_you_know [
     :branch,


### PR DESCRIPTION
Addint the Linear URL to commit messages is actively harmful, because it breaks Linear <-> Gitlab integration.

When a MR is created, Linear is supposed to post a linkback that includes the description of the Linear issue. This is very useful, especially for Gitlab code reviews. However, if the description of the MR *already contains the Linear URL*, Linear decides that the linkback is already present and will never post it.